### PR TITLE
Vite workaround/node script

### DIFF
--- a/_helper/vite-workaround.js
+++ b/_helper/vite-workaround.js
@@ -1,0 +1,27 @@
+import path from "path";
+// var path = require("path"),
+import fs from "fs";
+//   fs = require("fs");
+
+function removeFiles(startPath, filter) {
+  //console.log('Starting from dir '+startPath+'/');
+
+  if (!fs.existsSync(startPath)) {
+    console.log("no dir ", startPath);
+    return;
+  }
+
+  var files = fs.readdirSync(startPath);
+  for (var i = 0; i < files.length; i++) {
+    var filename = path.join(startPath, files[i]);
+    var stat = fs.lstatSync(filename);
+    if (stat.isDirectory()) {
+      removeFiles(filename, filter); //recurse
+    } else if (filename.indexOf(filter) >= 0) {
+      console.log("-- removing: ", filename);
+      fs.unlinkSync(filename);
+    }
+  }
+}
+console.log("Starting Vite Workaround Scriot");
+removeFiles("node_modules/@material", ".js.map");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "svelte-kit build",
     "start": "svelte-kit start",
     "prepare": "npm run vite-workaround && npm run smui-theme-light && npm run smui-theme-dark",
-    "vite-workaround": "find node_modules/@material/ -name \"*.js.map\" -type f -delete",
+    "vite-workaround": "node _helper/vite-workaround.js",
     "smui-theme-light": "sass --no-source-map -I src/theme -I node_modules src/app.scss static/smui.css",
     "smui-theme-dark": "sass --no-source-map -I src/theme/dark -I node_modules src/app.scss static/smui-dark.css"
   },


### PR DESCRIPTION
As discussed in Discord we can use the node script for our vite Workaround, which is deleting the Sorucemap files for Material...

Confirmed that this works confirmed on Mac OS and on Windows, (but should run on other OSes too), which is the main benefit, as we, unfortunately, do not have `find` on Windows ;-)