### PR TITLE
add function to remove sourcemaps links

### DIFF
--- a/_helper/vite-workaround.js
+++ b/_helper/vite-workaround.js
@@ -19,6 +19,29 @@ function removeFiles(startPath, filter) {
     }
   }
 }
+function removeSourceMaps(startPath) {
+  if (!fs.existsSync(startPath)) {
+    console.log("no dir ", startPath);
+    return;
+  }
+
+  var files = fs.readdirSync(startPath);
+  for (var i = 0; i < files.length; i++) {
+    var filename = path.join(startPath, files[i]);
+    var stat = fs.lstatSync(filename);
+    if (stat.isDirectory()) {
+      removeSourceMaps(filename); //recurse
+    } else if (filename.endsWith(".js")) {
+      let fileContent = fs.readFileSync(filename).toString();
+      let result = fileContent.replace(/^\/\/# sourceMappingURL=.+$/gm, "");
+      if (result !== fileContent) {
+        console.log("-- removing SourceMap: ", filename);
+        fs.writeFileSync(filename, result);
+      }
+    }
+  }
+}
 
 console.log("Starting Vite Workaround Script");
 removeFiles("node_modules/@material", ".js.map");
+removeSourceMaps("node_modules/@material");


### PR DESCRIPTION
This fixes the warnings #3 by removing all the sourcemaps links on the `@material` files